### PR TITLE
Remove error catcher for bitstomach input

### DIFF
--- a/bit_stomach/student_t_cleaner.py
+++ b/bit_stomach/student_t_cleaner.py
@@ -46,12 +46,12 @@ def student_t_cleaner(perf_dataframe):
 
 
 
-
+    '''
     ## Check if there are no measures with more than 3 unique months after cleaning
     # NOTE: still allows through data for measures with less than 3 months, but if selected we will only get text feedback so that should work.
-    if perf_dataframe.groupby('measure')['month'].nunique().max() <= 3:
+    if perf_dataframe.groupby('measure')['month'].nunique().max() < 3:
         logger.error(f"Not enough significant data detected in performance block, aborting feedback...")
         raise ValueError("PROCESS_ABORTED")
-
+    '''
     return perf_dataframe
 


### PR DESCRIPTION
Remove error catcher for preventing feedback when dataframe is too small.


Will still cause now-unhandled 500 errors when all data has been removed from the dataframe passed to BitStomach.