### PR TITLE
Remove measures from consideration if one month has insignificant data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 catalog-v001.xml
+*.ipynb
 
 # Abstract template and build artifacts
 doc/**/*.pdf

--- a/bit_stomach/student_t_cleaner.py
+++ b/bit_stomach/student_t_cleaner.py
@@ -12,7 +12,7 @@ logger.add(sys.stdout, colorize=True, format="{level} | {message}")
 ### Clean dataframe of measures where statistical significance cannot be determined from analysis
 # Shoutout St. James Gate
 def student_t_cleaner(perf_dataframe):
-    logger.debug(f"Running bit_stomach.student_t_cleaner...")
+    logger.trace(f"Running bit_stomach.student_t_cleaner...")
     # Create a list to store indices of rows to be removed
     cleaned_rows = []
 
@@ -20,6 +20,10 @@ def student_t_cleaner(perf_dataframe):
     for index, row in perf_dataframe.iterrows():
         if row['denominator'] < 10:
             cleaned_rows.append(index)
+
+            # Also, add all indices of rows with the matching measure
+            measure_rows = perf_dataframe[perf_dataframe['measure'] == row['measure']]
+            cleaned_rows.extend(measure_rows.index)
 
     # Remove rows that need to be cleaned (insignificant denominators, non-current month)
     if cleaned_rows:

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ This changelog format is based on [Keep a Changelog](https://keepachangelog.com/
 ### Release date: (unreleased)
 **Added:** student_t_cleaner to BitStomach
 - cleans data of denominators less than ten
+    - Removes any measure with data that is historically insignificant (<10)
+    - May be restrictive, however can add a sunset period at a later date to allow feedback on measures where data has been significant for >6 months
 - cleans data of measures lacking data for the most recent month's performance
 - exits gracefully with 200 code response when no data remains for feedback generation
 


### PR DESCRIPTION
See linked issue for issue details and more details on the solution, reproduction of the bug, and verification steps.

NOTE: does not just search the latest month, removes measures when ANY month has insignificant data.

Resolves #178 