### PR TITLE
fixing the Graph.objects function call by removing the extra paramete…

### DIFF
--- a/esteemer2/utils.py
+++ b/esteemer2/utils.py
@@ -216,7 +216,7 @@ def candidate_as_dictionary(a_candidate: BNode, performer_graph: Graph) -> dict:
             a_candidate, URIRef("http://example.com/slowmo#name"), None
         )
     representation["acceptable_by"] = list(performer_graph.objects(
-            a_candidate, URIRef("slowmo:acceptable_by"), None
+            a_candidate, URIRef("slowmo:acceptable_by")
         )) #converting to list ro allow repeated access
     representation["selected"] = performer_graph.value(a_candidate, URIRef("slowmo:selected"), None)
            


### PR DESCRIPTION
…r at the end.

The candidate_as_dictionary method gives an error in some environments which have an older version of rdflib installed (i. e. you won't see this error if you have rdflib 6.3.2 installed but you will get it if you have rdflib 6.1.1)

The Graph().objects() method only need the subject and predicate and the third parameter (unique) is optional but it is boolean and can not have value None in older versions of rdflib. Simply need to remove it from the call for it to work in all versions.