### PR TITLE
chore: remove Poetry-specific configuration, migrate to uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,29 +26,15 @@ dependencies = [
 
 ]
 
-[project.optional-dependencies]
-dev = [
-  "python-slugify>=8.0.4,<9.0.0",
-  "decoy>=2.1.2,<3.0.0",
-  "poethepoet>=0.34.0,<1.0.0",
-]
-
 [tool.setuptools.packages.find]
 include  = ["src*"]
 
 [project.scripts]
 pipeline = "src.cli:cli"
 
-# keep your existing tool configs
 [tool.ruff.lint]
 extend-select = ["I", "C901"]
 mccabe.max-complexity = 5
-
-[tool.poe.tasks]
-ruff = [
-  { cmd = "ruff check --fix --exit-zero" },
-  { cmd = "ruff format" }
-]
 
 [build-system]
 requires = ["setuptools", "wheel"]
@@ -58,4 +44,6 @@ build-backend = "setuptools.build_meta"
 dev = [
     "pytest>=8.4.2",
     "ruff>=0.15.12",
+    "python-slugify>=8.0.4,<9.0.0",
+    "decoy>=2.1.2,<3.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -883,9 +883,7 @@ dependencies = [
 dev = [
     { name = "decoy" },
     { name = "poethepoet" },
-    { name = "pytest" },
     { name = "python-slugify" },
-    { name = "ruff" },
 ]
 
 [package.dev-dependencies]
@@ -906,13 +904,11 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.3,<3.0.0" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.34.0,<1.0.0" },
     { name = "psutil", specifier = ">=7.0.0,<8.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5,<9.0.0" },
     { name = "python-decouple", specifier = ">=3.8,<4.0.0" },
     { name = "python-slugify", marker = "extra == 'dev'", specifier = ">=8.0.4,<9.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2,<7.0.0" },
     { name = "rdflib", specifier = ">=7.1.4,<8.0.0" },
     { name = "requests-file", specifier = ">=2.1.0,<3.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.6,<1.0.0" },
     { name = "typer", specifier = ">=0.15.2,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.34.2,<1.0.0" },
 ]


### PR DESCRIPTION
Closes #553

## Changes

- Removed `[project.optional-dependencies]` dev group (Poetry/extras style) — was duplicating the uv-native `[dependency-groups]`
- Removed `poethepoet` from dependencies
- Removed `[tool.poe.tasks]` task runner section
- Merged `python-slugify` and `decoy` into `[dependency-groups]` dev (PEP 735 / uv standard)
- Removed stale `# keep your existing tool configs` comment